### PR TITLE
Initial breaking changes

### DIFF
--- a/schemerz-postgres/CHANGELOG.md
+++ b/schemerz-postgres/CHANGELOG.md
@@ -9,6 +9,12 @@ and this library adheres to Rust's notion of
 <!-- next-header -->
 ## [Unreleased]
 
+### Changed
+- **IMPORTANT BREAKING CHANGE**: `schemerz_postgres::PostgresAdapter::new` now
+  uses a default table name of `_schemerz` when the `table_name` argument is
+  `None`. If you were not setting this argument before and are migrating from
+  `schemer`, you will need to set `table_name` to `Some("_schemer".into())`.
+
 ## [0.190.0] - 2024-10-15
 Initial release. The API is identical to `schemer-postgres 0.2.0`.
 

--- a/schemerz-postgres/src/lib.rs
+++ b/schemerz-postgres/src/lib.rs
@@ -173,7 +173,7 @@ impl<'a> Adapter for PostgresAdapter<'a> {
 mod tests {
     use super::*;
     use postgres::NoTls;
-    use schemerz::test_schemer_adapter;
+    use schemerz::test_schemerz_adapter;
     use schemerz::testing::*;
 
     impl PostgresMigration for TestMigration {}
@@ -196,7 +196,7 @@ mod tests {
         adapter
     }
 
-    test_schemer_adapter!(
+    test_schemerz_adapter!(
         let mut conn = build_test_connection(),
         build_test_adapter(&mut conn));
 }

--- a/schemerz-postgres/src/lib.rs
+++ b/schemerz-postgres/src/lib.rs
@@ -102,7 +102,7 @@ impl<'a> PostgresAdapter<'a> {
     pub fn new(conn: &'a mut Client, table_name: Option<String>) -> PostgresAdapter<'a> {
         PostgresAdapter {
             conn,
-            migration_metadata_table: table_name.unwrap_or_else(|| "_schemer".into()),
+            migration_metadata_table: table_name.unwrap_or_else(|| "_schemerz".into()),
         }
     }
 

--- a/schemerz-rusqlite/CHANGELOG.md
+++ b/schemerz-rusqlite/CHANGELOG.md
@@ -9,6 +9,12 @@ and this library adheres to Rust's notion of
 <!-- next-header -->
 ## [Unreleased]
 
+### Changed
+- **IMPORTANT BREAKING CHANGE**: `schemerz_rusqlite::RusqliteAdapter::new` now
+  uses a default table name of `_schemerz` when the `table_name` argument is
+  `None`. If you were not setting this argument before and are migrating from
+  `schemer`, you will need to set `table_name` to `Some("_schemer".into())`.
+
 ## [0.290.0] - 2024-10-15
 Initial release. The API is identical to `schemer-rusqlite 0.2.2`.
 

--- a/schemerz-rusqlite/src/lib.rs
+++ b/schemerz-rusqlite/src/lib.rs
@@ -114,7 +114,7 @@ impl<'a, E> RusqliteAdapter<'a, E> {
     pub fn new(conn: &'a mut Connection, table_name: Option<String>) -> RusqliteAdapter<'a, E> {
         RusqliteAdapter {
             conn,
-            migration_metadata_table: table_name.unwrap_or_else(|| "_schemer".into()),
+            migration_metadata_table: table_name.unwrap_or_else(|| "_schemerz".into()),
             _err: PhantomData,
         }
     }

--- a/schemerz-rusqlite/src/lib.rs
+++ b/schemerz-rusqlite/src/lib.rs
@@ -194,7 +194,7 @@ impl<'a, E: From<RusqliteError> + Sync + Send + Error + 'static> Adapter
 mod tests {
     use super::*;
     use rusqlite::Error as RusqliteError;
-    use schemerz::test_schemer_adapter;
+    use schemerz::test_schemerz_adapter;
     use schemerz::testing::*;
 
     impl RusqliteMigration for TestMigration {
@@ -217,7 +217,7 @@ mod tests {
         adapter
     }
 
-    test_schemer_adapter!(
+    test_schemerz_adapter!(
         let mut conn = build_test_connection(),
         build_test_adapter(&mut conn));
 }

--- a/schemerz/CHANGELOG.md
+++ b/schemerz/CHANGELOG.md
@@ -9,6 +9,12 @@ and this library adheres to Rust's notion of
 <!-- next-header -->
 ## [Unreleased]
 
+### Added
+- `schemerz::test_schemerz_adapter`
+
+### Removed
+- `schemerz::test_schemer_adapter` (use `test_schemerz_adapter` instead).
+
 ## [0.1.0] - 2024-10-15
 Initial release. The API is identical to `schemer 0.2.1`.
 

--- a/schemerz/src/lib.rs
+++ b/schemerz/src/lib.rs
@@ -403,5 +403,5 @@ pub mod tests {
         }
     }
 
-    test_schemer_adapter!(DefaultTestAdapter::new());
+    test_schemerz_adapter!(DefaultTestAdapter::new());
 }

--- a/schemerz/src/testing.rs
+++ b/schemerz/src/testing.rs
@@ -54,15 +54,15 @@ impl Migration for TestMigration {
 ///     MyAdapterType {}
 /// }
 ///
-/// test_schemer_adapter!(construct_my_adapter_test_fixture());
+/// test_schemerz_adapter!(construct_my_adapter_test_fixture());
 /// ```
 #[macro_export]
-macro_rules! test_schemer_adapter {
+macro_rules! test_schemerz_adapter {
     ($constructor:expr) => {
-        test_schemer_adapter!({}, $constructor);
+        test_schemerz_adapter!({}, $constructor);
     };
     ($setup:stmt, $constructor:expr) => {
-        test_schemer_adapter!($setup, $constructor,
+        test_schemerz_adapter!($setup, $constructor,
             test_single_migration,
             test_migration_chain,
             test_multi_component_dag,


### PR DESCRIPTION
These are necessary changes vs `schemer` that I didn't do in #1 to keep `schemerz 0.1.0` intentionally compatible with the latest version of `schemer`, but that need to be done going forward.